### PR TITLE
Fix edge label going to 0,0

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -580,8 +580,12 @@ class Edge {
         ctx.save();
 
         let rotationPoint = this._getRotation(ctx);
-        if (rotationPoint.angle != 0) {
+        if (!isNaN(rotationPoint.x) && !isNaN(rotationPoint.y)) {
           ctx.translate(rotationPoint.x, rotationPoint.y);
+        } else {
+          ctx.translate(node1.x, node1.y);
+        }
+        if (rotationPoint.angle != 0) {
           ctx.rotate(rotationPoint.angle);
         }
 


### PR DESCRIPTION
- happens when `from.y = to.y && from.x >= to.x && options.edges.font.align != 'horizontal'`